### PR TITLE
Add 'Open with Codeanywhere' badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 3D printer management and monitoring for makerspaces.
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/tomglennhs/enok)
+[![Open in Codeanywhere](https://codeanywhere.com/img/open-in-codeanywhere-btn.svg)](https://app.codeanywhere.com/#https://github.com/tomglennhs/enok)
 
 This repo contains Enok's API, which is written in Python and utilizes FastAPI and stores data in a SQLite database. If you aren't familiar with FastAPI, take a look at [https://fastapi.tiangolo.com/tutorial/](https://fastapi.tiangolo.com/tutorial/).
 


### PR DESCRIPTION
With Codeanywhere, developers and contributors can instantly launch a cloud or local IDE with a pre-configured remote development environment. One can work in the cloud or locally, and it ensures all contributors have access to the same, ready-to-use dev env.